### PR TITLE
refactor: restructure leave management frontend with reusable components and improved UI/UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.0.2",
-        "@mui/material": "^7.0.2",
+        "@mui/material": "^7.1.0",
         "@mui/x-date-pickers": "^8.1.0",
         "axios": "^1.9.0",
         "dayjs": "^1.11.13",
@@ -273,12 +273,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1213,9 +1210,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.0.2.tgz",
-      "integrity": "sha512-TfeFU9TgN1N06hyb/pV/63FfO34nijZRMqgHk0TJ3gkl4Fbd+wZ73+ZtOd7jag6hMmzO9HSrBc6Vdn591nhkAg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.1.0.tgz",
+      "integrity": "sha512-E0OqhZv548Qdc0PwWhLVA2zmjJZSTvaL4ZhoswmI8NJEC1tpW2js6LLP827jrW9MEiXYdz3QS6+hask83w74yQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -1247,15 +1244,15 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.0.2.tgz",
-      "integrity": "sha512-rjJlJ13+3LdLfobRplkXbjIFEIkn6LgpetgU/Cs3Xd8qINCCQK9qXQIjjQ6P0FXFTPFzEVMj0VgBR1mN+FhOcA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.1.0.tgz",
+      "integrity": "sha512-ahUJdrhEv+mCp4XHW+tHIEYzZMSRLg8z4AjUOsj44QpD1ZaMxQoVOG2xiHvLFdcsIPbgSRx1bg1eQSheHBgvtg==",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
-        "@mui/core-downloads-tracker": "^7.0.2",
-        "@mui/system": "^7.0.2",
-        "@mui/types": "^7.4.1",
-        "@mui/utils": "^7.0.2",
+        "@babel/runtime": "^7.27.1",
+        "@mui/core-downloads-tracker": "^7.1.0",
+        "@mui/system": "^7.1.0",
+        "@mui/types": "^7.4.2",
+        "@mui/utils": "^7.1.0",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -1274,7 +1271,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.0.2",
+        "@mui/material-pigment-css": "^7.1.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1295,12 +1292,12 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.0.2.tgz",
-      "integrity": "sha512-6lt8heDC9wN8YaRqEdhqnm0cFCv08AMf4IlttFvOVn7ZdKd81PNpD/rEtPGLLwQAFyyKSxBG4/2XCgpbcdNKiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.1.0.tgz",
+      "integrity": "sha512-4Kck4jxhqF6YxNwJdSae1WgDfXVg0lIH6JVJ7gtuFfuKcQCgomJxPvUEOySTFRPz1IZzwz5OAcToskRdffElDA==",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
-        "@mui/utils": "^7.0.2",
+        "@babel/runtime": "^7.27.1",
+        "@mui/utils": "^7.1.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1321,11 +1318,11 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.0.2.tgz",
-      "integrity": "sha512-11Bt4YdHGlh7sB8P75S9mRCUxTlgv7HGbr0UKz6m6Z9KLeiw1Bm9y/t3iqLLVMvSHYB6zL8X8X+LmfTE++gyBw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.1.0.tgz",
+      "integrity": "sha512-m0mJ0c6iRC+f9hMeRe0W7zZX1wme3oUX0+XTVHjPG7DJz6OdQ6K/ggEOq7ZdwilcpdsDUwwMfOmvO71qDkYd2w==",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
+        "@babel/runtime": "^7.27.1",
         "@emotion/cache": "^11.13.5",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -1354,15 +1351,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.0.2.tgz",
-      "integrity": "sha512-yFUraAWYWuKIISPPEVPSQ1NLeqmTT4qiQ+ktmyS8LO/KwHxB+NNVOacEZaIofh5x1NxY8rzphvU5X2heRZ/RDA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.1.0.tgz",
+      "integrity": "sha512-iedAWgRJMCxeMHvkEhsDlbvkK+qKf9me6ofsf7twk/jfT4P1ImVf7Rwb5VubEA0sikrVL+1SkoZM41M4+LNAVA==",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
-        "@mui/private-theming": "^7.0.2",
-        "@mui/styled-engine": "^7.0.2",
-        "@mui/types": "^7.4.1",
-        "@mui/utils": "^7.0.2",
+        "@babel/runtime": "^7.27.1",
+        "@mui/private-theming": "^7.1.0",
+        "@mui/styled-engine": "^7.1.0",
+        "@mui/types": "^7.4.2",
+        "@mui/utils": "^7.1.0",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -1393,11 +1390,11 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.1.tgz",
-      "integrity": "sha512-gUL8IIAI52CRXP/MixT1tJKt3SI6tVv4U/9soFsTtAsHzaJQptZ42ffdHZV3niX1ei0aUgMvOxBBN0KYqdG39g==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.2.tgz",
+      "integrity": "sha512-edRc5JcLPsrlNFYyTPxds+d5oUovuUxnnDtpJUbP6WMeV4+6eaX/mqai1ZIWT62lCOe0nlrON0s9HDiv5en5bA==",
       "dependencies": {
-        "@babel/runtime": "^7.27.0"
+        "@babel/runtime": "^7.27.1"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1409,12 +1406,12 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.0.2.tgz",
-      "integrity": "sha512-72gcuQjPzhj/MLmPHLCgZjy2VjOH4KniR/4qRtXTTXIEwbkgcN+Y5W/rC90rWtMmZbjt9svZev/z+QHUI4j74w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.1.0.tgz",
+      "integrity": "sha512-/OM3S8kSHHmWNOP+NH9xEtpYSG10upXeQ0wLZnfDgmgadTAk5F4MQfFLyZ5FCRJENB3eRzltMmaNl6UtDnPovw==",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
-        "@mui/types": "^7.4.1",
+        "@babel/runtime": "^7.27.1",
+        "@mui/types": "^7.4.2",
         "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
@@ -5181,11 +5178,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.0.2",
-    "@mui/material": "^7.0.2",
+    "@mui/material": "^7.1.0",
     "@mui/x-date-pickers": "^8.1.0",
     "axios": "^1.9.0",
     "dayjs": "^1.11.13",

--- a/src/components/FileUploadButton.tsx
+++ b/src/components/FileUploadButton.tsx
@@ -1,0 +1,29 @@
+import { Button, Typography, Stack } from '@mui/material';
+import React from 'react';
+
+interface Props {
+  file: File | null;
+  fileName: string;
+  onFileChange: (f: File | null) => void;
+}
+
+export default function FileUploadButton({ file, fileName, onFileChange }: Props) {
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0] || null;
+    onFileChange(selected);
+  };
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={1}>
+      <label>
+        <input type="file" hidden onChange={handleFileInput} />
+        <Button variant="outlined" component="span" size="small">
+          上傳附件
+        </Button>
+      </label>
+      <Typography variant="body2" color="text.secondary">
+        {fileName || '未選擇檔案'}
+      </Typography>
+    </Stack>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -117,7 +117,7 @@ export default function Layout() {
         style={{
           width: '100%',
           boxSizing: 'border-box',
-          paddingTop: '88px', // 預留 header 高度 + 安全間距
+          paddingTop: '88px',
         }}
       >
         <div style={containerStyle}>

--- a/src/components/LeaveStatusChip.tsx
+++ b/src/components/LeaveStatusChip.tsx
@@ -1,0 +1,20 @@
+import { Chip } from '@mui/material';
+
+export default function LeaveStatusChip({ status }: { status: string }) {
+  switch (status) {
+    case '待審核':
+    case 'PENDING':
+      return <Chip label="待審核" color="default" />;
+    case '已核准':
+    case 'APPROVED':
+      return <Chip label="已核准" color="success" />;
+    case '已拒絕':
+    case 'REJECTED':
+      return <Chip label="已拒絕" color="error" />;
+    case '已取消':
+    case 'CANCELED':
+      return <Chip label="已取消" color="default" />;
+    default:
+      return <Chip label={status} />;
+  }
+}

--- a/src/components/LeaveTable.tsx
+++ b/src/components/LeaveTable.tsx
@@ -1,0 +1,108 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Tooltip,
+  Typography,
+  Link,
+} from '@mui/material';
+import LeaveStatusChip from './LeaveStatusChip';
+import { downloadAttachment } from '../api/leave';
+import { formatDateTime } from '../utils/formats';
+
+interface Props {
+  data: any[];
+  onRowClick: (id: number) => void;
+}
+
+const renderCell = (value?: string) => formatDateTime(value);
+
+export default function LeaveTable({ data, onRowClick }: Props) {
+  return (
+    <TableContainer component={Paper}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ minWidth: 80 }}>申請時間</TableCell>
+            <TableCell sx={{ minWidth: 60 }}>假別</TableCell>
+            <TableCell sx={{ minWidth: 120 }}>審核時間</TableCell>
+            <TableCell sx={{ minWidth: 120 }}>請假時間</TableCell>
+            <TableCell sx={{ minWidth: 120 }}>結束時間</TableCell>
+            <TableCell sx={{ minWidth: 100 }}>請假時數</TableCell>
+            <TableCell sx={{ minWidth: 200 }}>請假原因</TableCell>
+            <TableCell sx={{ minWidth: 200 }}>主管留言</TableCell>
+            <TableCell sx={{ minWidth: 120 }}>代理人員編</TableCell>
+            <TableCell sx={{ minWidth: 80 }}>代理人姓名</TableCell>
+            <TableCell sx={{ minWidth: 60 }}>附件</TableCell>
+            <TableCell sx={{ minWidth: 100 }}>申請狀態</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map((row) => (
+            <TableRow
+              key={row.applicationId}
+              hover
+              onClick={() => onRowClick(row.applicationId)}
+              style={{ cursor: 'pointer' }}
+            >
+              <TableCell>{row.applicationDateTime?.split('T')[0] || '—'}</TableCell>
+              <TableCell>{row.leaveTypeName}</TableCell>
+              <TableCell>{renderCell(row.approvalDatetime)}</TableCell>
+              <TableCell>{renderCell(row.startDateTime)}</TableCell>
+              <TableCell>{renderCell(row.endDateTime)}</TableCell>
+              <TableCell>
+                {row.leaveHours} 小時 ({(row.leaveHours / 8).toFixed(1)} 天)
+              </TableCell>
+              <TableCell>
+                <Tooltip title={row.reason || ''}>
+                  <Typography
+                    sx={{
+                      maxWidth: 200,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {row.reason || '—'}
+                  </Typography>
+                </Tooltip>
+              </TableCell>
+              <TableCell>
+                <Tooltip title={row.approvalReason || ''}>
+                  <Typography
+                    sx={{
+                      maxWidth: 200,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {row.approvalReason || '—'}
+                  </Typography>
+                </Tooltip>
+              </TableCell>
+              <TableCell>{row.proxyEmployeeCode || '—'}</TableCell>
+              <TableCell>{row.proxyEmployeeName || '—'}</TableCell>
+              <TableCell>
+                {row.fileName ? (
+                  <Link href={downloadAttachment(row.fileName)} target="_blank" rel="noopener">
+                    🔗
+                  </Link>
+                ) : (
+                  '—'
+                )}
+              </TableCell>
+              <TableCell>
+                <LeaveStatusChip status={row.status} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/components/LeaveTimePickerGroup.tsx
+++ b/src/components/LeaveTimePickerGroup.tsx
@@ -1,0 +1,50 @@
+import { DatePicker, TimePicker } from '@mui/x-date-pickers';
+import { Grid } from '@mui/material';
+import dayjs, { Dayjs } from 'dayjs';
+
+interface Props {
+  label: string;
+  date: Dayjs | null;
+  time: Dayjs | null;
+  setDate: (d: Dayjs | null) => void;
+  setTime: (t: Dayjs | null) => void;
+  disableDate?: (date: Dayjs) => boolean;
+}
+
+export default function LeaveTimePickerGroup({
+  label,
+  date,
+  time,
+  setDate,
+  setTime,
+  disableDate,
+}: Props) {
+  return (
+    <>
+      <label style={{ fontWeight: 600 }}>{label}</label>
+      <Grid container spacing={2} sx={{ my: 1 }}>
+        <Grid item xs={6}>
+          <DatePicker
+            label="日期"
+            value={date}
+            onChange={setDate}
+            shouldDisableDate={disableDate}
+            slotProps={{ textField: { size: 'small', fullWidth: true } }}
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <TimePicker
+            label="時間"
+            value={time}
+            onChange={setTime}
+            ampm={false}
+            views={['hours']}
+            minTime={dayjs().hour(9)}
+            maxTime={dayjs().hour(18)}
+            slotProps={{ textField: { size: 'small', fullWidth: true } }}
+          />
+        </Grid>
+      </Grid>
+    </>
+  );
+}

--- a/src/components/LeaveTypeRadioGroup.tsx
+++ b/src/components/LeaveTypeRadioGroup.tsx
@@ -1,0 +1,31 @@
+import { FormControl, FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material';
+
+interface Props {
+  leaveTypeId: number;
+  setLeaveTypeId: (val: number) => void;
+}
+
+const leaveTypes = [
+  { id: 1, label: '特休' },
+  { id: 2, label: '病假' },
+  { id: 3, label: '事假' },
+];
+
+export default function LeaveTypeRadioGroup({ leaveTypeId, setLeaveTypeId }: Props) {
+  return (
+    <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+      <FormLabel>假別</FormLabel>
+      <RadioGroup row value={leaveTypeId} onChange={(e) => setLeaveTypeId(Number(e.target.value))}>
+        {leaveTypes.map((t) => (
+          <FormControlLabel
+            key={t.id}
+            value={t.id}
+            control={<Radio />}
+            label={t.label}
+            sx={{ color: 'text.primary' }}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+}

--- a/src/components/LoadingFallback.tsx
+++ b/src/components/LoadingFallback.tsx
@@ -1,0 +1,12 @@
+import { Box, CircularProgress, Typography } from '@mui/material';
+
+export default function LoadingFallback({ text = '載入中...' }: { text?: string }) {
+  return (
+    <Box
+      sx={{ minHeight: '50vh', display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+    >
+      <CircularProgress />
+      <Typography sx={{ ml: 2 }}>{text}</Typography>
+    </Box>
+  );
+}

--- a/src/hooks/useLeaveHoursCalculator.ts
+++ b/src/hooks/useLeaveHoursCalculator.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import { Dayjs } from 'dayjs';
+
+export function useLeaveHoursCalculator(
+  start: Dayjs | null,
+  end: Dayjs | null,
+  holidays: string[],
+) {
+  return useMemo(() => {
+    if (!start || !end || !end.isAfter(start)) return 0;
+
+    let hours = 0;
+    let curr = start.startOf('hour');
+
+    while (curr.isBefore(end)) {
+      const isHoliday = holidays.includes(curr.format('YYYY-MM-DD'));
+      const isWeekend = curr.day() === 0 || curr.day() === 6;
+      const hour = curr.hour();
+
+      if (!isHoliday && !isWeekend && hour >= 9 && hour < 18) {
+        hours += 1;
+      }
+
+      curr = curr.add(1, 'hour');
+    }
+
+    return hours;
+  }, [start, end, holidays]);
+}

--- a/src/hooks/useProxiesAndHolidays.ts
+++ b/src/hooks/useProxiesAndHolidays.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { getProxies } from '../api/employee';
+import { getTaiwanHolidays } from '../api/holiday';
+import dayjs from 'dayjs';
+
+export function useProxiesAndHolidays() {
+  const [proxies, setProxies] = useState<any[]>([]);
+  const [holidays, setHolidays] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const [proxyList, holidayList] = await Promise.all([getProxies(), getTaiwanHolidays()]);
+        setProxies(proxyList);
+        setHolidays(holidayList.map((d) => dayjs(d).format('YYYY-MM-DD')));
+      } catch (err) {
+        console.error('代理人與假日載入失敗:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetch();
+  }, []);
+
+  return { proxies, holidays, loading };
+}

--- a/src/pages/EmployeePage.tsx
+++ b/src/pages/EmployeePage.tsx
@@ -1,4 +1,3 @@
-// EmployeePage.tsx
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getEmployeeProfile, getProxies, getSupervisor } from '../api/employee';
@@ -20,14 +19,12 @@ function EmployeePage() {
           data.monthOfService = months;
         }
         setProfile(data);
-  
-        // 這裡新增的部分
+
         const supervisor = await getSupervisor();
         console.log('主管:', supervisor);
-  
+
         const proxies = await getProxies();
         console.log('代理人:', proxies);
-  
       } catch (err) {
         console.error('取得個人資料失敗', err);
         navigate('/login');
@@ -35,7 +32,7 @@ function EmployeePage() {
         setLoading(false);
       }
     };
-  
+
     fetchProfile();
   }, [navigate]);
 

--- a/src/pages/LeaveDetailDialog.tsx
+++ b/src/pages/LeaveDetailDialog.tsx
@@ -1,3 +1,4 @@
+// LeaveDetailDialog.tsx
 import { useEffect, useState } from 'react';
 import {
   Dialog,
@@ -5,16 +6,19 @@ import {
   DialogContent,
   DialogActions,
   Button,
-  Grid,
   Typography,
   TextField,
   Select,
   MenuItem,
   Stack,
 } from '@mui/material';
-import dayjs from 'dayjs';
+import Grid2 from '@mui/material/Grid';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider, DatePicker, TimePicker } from '@mui/x-date-pickers';
+import dayjs, { Dayjs } from 'dayjs';
 import { getProxies } from '../api/employee';
 import { uploadFile, getLeaveDetail, updateLeave } from '../api/leave';
+import { getTaiwanHolidays } from '../api/holiday';
 
 interface Props {
   open: boolean;
@@ -29,50 +33,72 @@ export default function LeaveDetailDialog({ open, onClose, leaveId, onSuccess }:
   const [proxies, setProxies] = useState<any[]>([]);
   const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState('');
+  const [holidays, setHolidays] = useState<string[]>([]);
+  const [startDate, setStartDate] = useState<Dayjs | null>(null);
+  const [startTime, setStartTime] = useState<Dayjs | null>(null);
+  const [endDate, setEndDate] = useState<Dayjs | null>(null);
+  const [endTime, setEndTime] = useState<Dayjs | null>(null);
 
   useEffect(() => {
     if (leaveId && open) {
-      Promise.all([getLeaveDetail(leaveId), getProxies()]).then(([detail, proxyList]) => {
-        console.log('取得請假資料：', detail);
-        setData(detail);
-        setProxies(proxyList);
-        setIsEditing(false);
-        setFileName(detail.fileName || '');
-      });
+      Promise.all([getLeaveDetail(leaveId), getProxies(), getTaiwanHolidays()]).then(
+        ([detail, proxyList, holidayList]) => {
+          setData(detail);
+          setProxies(proxyList);
+          setHolidays(holidayList.map((d) => dayjs(d).format('YYYY-MM-DD')));
+          setIsEditing(false);
+          setFileName(detail.fileName || '');
+          const s = dayjs(detail.startDateTime);
+          const e = dayjs(detail.endDateTime);
+          setStartDate(s.startOf('day'));
+          setStartTime(s);
+          setEndDate(e.startOf('day'));
+          setEndTime(e);
+        },
+      );
     }
   }, [leaveId, open]);
+
+  const disableDate = (date: Dayjs) => {
+    const day = date.day();
+    return day === 0 || day === 6 || holidays.includes(date.format('YYYY-MM-DD'));
+  };
+
+  useEffect(() => {
+    if (startDate && startTime && endDate && endTime && data) {
+      const start = startDate.hour(startTime.hour()).minute(startTime.minute());
+      const end = endDate.hour(endTime.hour()).minute(endTime.minute());
+
+      const updated = { ...data };
+      updated.startDateTime = start.toISOString();
+      updated.endDateTime = end.toISOString();
+      updated.leaveHours = calculateLeaveHours(start.toISOString(), end.toISOString());
+      setData(updated);
+    }
+  }, [startDate, startTime, endDate, endTime]);
 
   const calculateLeaveHours = (startStr: string, endStr: string) => {
     const start = dayjs(startStr);
     const end = dayjs(endStr);
     if (!start.isValid() || !end.isValid() || !end.isAfter(start)) return 0;
 
-    const startDay = start.startOf('day');
-    const endDay = end.startOf('day');
-    const dayDiff = endDay.diff(startDay, 'day');
-
     let hours = 0;
-    if (dayDiff === 0) {
-      const startHour = Math.max(start.hour(), 9);
-      const endHour = Math.min(end.hour(), 18);
-      hours = endHour > startHour ? endHour - startHour : 0;
-    } else {
-      const firstDayHours = 18 - Math.max(start.hour(), 9);
-      const lastDayHours = Math.min(end.hour(), 18) - 9;
-      const fullDays = dayDiff - 1;
-      hours =
-        (firstDayHours > 0 ? firstDayHours : 0) +
-        (fullDays > 0 ? fullDays * 8 : 0) +
-        (lastDayHours > 0 ? lastDayHours : 0);
+    let curr = start.startOf('hour');
+
+    while (curr.isBefore(end)) {
+      const isHoliday = holidays.includes(curr.format('YYYY-MM-DD'));
+      const isWeekend = curr.day() === 0 || curr.day() === 6;
+      if (!isHoliday && !isWeekend) {
+        const hour = curr.hour();
+        if (hour >= 9 && hour < 18) hours += 1;
+      }
+      curr = curr.add(1, 'hour');
     }
     return hours;
   };
 
   const handleChange = (field: string, value: any) => {
     const updated = { ...data, [field]: value };
-    if (field === 'startDateTime' || field === 'endDateTime') {
-      updated.leaveHours = calculateLeaveHours(updated.startDateTime, updated.endDateTime);
-    }
     setData(updated);
   };
 
@@ -100,7 +126,6 @@ export default function LeaveDetailDialog({ open, onClose, leaveId, onSuccess }:
       filePath: uploadedPath,
       fileName: uploadedName,
     };
-    console.log('送出更新資料：', payload);
     await updateLeave(leaveId!, payload);
     onSuccess();
     onClose();
@@ -112,96 +137,139 @@ export default function LeaveDetailDialog({ open, onClose, leaveId, onSuccess }:
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>請假紀錄詳情</DialogTitle>
       <DialogContent dividers>
-        <Grid container spacing={2}>
-          <Grid item xs={6}>
-            <Typography variant="caption">申請人</Typography>
-            <Typography>{data.employeeName}</Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="caption">假別</Typography>
-            <Typography>{data.leaveTypeName}</Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="caption">開始時間</Typography>
-            {isEditing ? (
-              <TextField
-                fullWidth
-                type="datetime-local"
-                value={dayjs(data.startDateTime).format('YYYY-MM-DDTHH:mm')}
-                onChange={(e) => handleChange('startDateTime', e.target.value)}
-              />
-            ) : (
-              <Typography>{dayjs(data.startDateTime).format('YYYY/MM/DD HH:mm')}</Typography>
-            )}
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="caption">結束時間</Typography>
-            {isEditing ? (
-              <TextField
-                fullWidth
-                type="datetime-local"
-                value={dayjs(data.endDateTime).format('YYYY-MM-DDTHH:mm')}
-                onChange={(e) => handleChange('endDateTime', e.target.value)}
-                InputLabelProps={{ shrink: true }}
-              />
-            ) : (
-              <Typography>{dayjs(data.endDateTime).format('YYYY/MM/DD HH:mm')}</Typography>
-            )}
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="caption">請假時數</Typography>
-            <Typography>{data.leaveHours} 小時</Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="caption">請假原因</Typography>
-            {isEditing ? (
-              <TextField
-                fullWidth
-                value={data.reason}
-                onChange={(e) => handleChange('reason', e.target.value)}
-                multiline
-                rows={3}
-              />
-            ) : (
-              <Typography>{data.reason || '—'}</Typography>
-            )}
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="caption">代理人</Typography>
-            {isEditing ? (
-              <Select
-                fullWidth
-                value={data.proxyEmployeeCode || ''}
-                onChange={(e) => handleChange('proxyEmployeeCode', e.target.value)}
-              >
-                <MenuItem value="">- 請選擇 -</MenuItem>
-                {proxies.map((p) => (
-                  <MenuItem key={p.employeeCode} value={p.employeeCode}>
-                    {p.employeeName}
-                  </MenuItem>
-                ))}
-              </Select>
-            ) : (
-              <Typography>{data.proxyEmployeeName || '—'}</Typography>
-            )}
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="caption">審核人</Typography>
-            <Typography>{data.approverEmployeeName || '—'}</Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="caption">附件</Typography>
-            <Stack direction="row" alignItems="center" spacing={1}>
-              {isEditing && (
-                <Button variant="outlined" component="label" size="small">
-                  重新上傳
-                  <input type="file" hidden onChange={handleFileChange} />
-                </Button>
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <Grid2 container columns={12} spacing={2}>
+            <Grid2 xs={6}>
+              <Typography variant="caption">申請人</Typography>
+              <Typography>{data.employeeName}</Typography>
+            </Grid2>
+            <Grid2 xs={6}>
+              <Typography variant="caption">假別</Typography>
+              <Typography>{data.leaveTypeName}</Typography>
+            </Grid2>
+
+            <Grid2 xs={12}>
+              <Typography variant="caption">開始時間</Typography>
+              {isEditing ? (
+                <Grid2 container columns={12} spacing={2}>
+                  <Grid2 xs={6}>
+                    <DatePicker
+                      label="開始日期"
+                      value={startDate}
+                      onChange={setStartDate}
+                      shouldDisableDate={disableDate}
+                      slotProps={{ textField: { size: 'small', fullWidth: true } }}
+                    />
+                  </Grid2>
+                  <Grid2 xs={6}>
+                    <TimePicker
+                      label="開始時間"
+                      ampm={false}
+                      views={['hours']}
+                      minTime={dayjs().hour(9)}
+                      maxTime={dayjs().hour(18)}
+                      value={startTime}
+                      onChange={setStartTime}
+                      slotProps={{ textField: { size: 'small', fullWidth: true } }}
+                    />
+                  </Grid2>
+                </Grid2>
+              ) : (
+                <Typography>{dayjs(data.startDateTime).format('YYYY/MM/DD HH:mm')}</Typography>
               )}
-              <Typography variant="body2">{fileName || data.fileName || '未選擇檔案'}</Typography>
-            </Stack>
-          </Grid>
-        </Grid>
+            </Grid2>
+
+            <Grid2 xs={12}>
+              <Typography variant="caption">結束時間</Typography>
+              {isEditing ? (
+                <Grid2 container columns={12} spacing={2}>
+                  <Grid2 xs={6}>
+                    <DatePicker
+                      label="結束日期"
+                      value={endDate}
+                      onChange={setEndDate}
+                      shouldDisableDate={disableDate}
+                      slotProps={{ textField: { size: 'small', fullWidth: true } }}
+                    />
+                  </Grid2>
+                  <Grid2 xs={6}>
+                    <TimePicker
+                      label="結束時間"
+                      ampm={false}
+                      views={['hours']}
+                      minTime={dayjs().hour(9)}
+                      maxTime={dayjs().hour(18)}
+                      value={endTime}
+                      onChange={setEndTime}
+                      slotProps={{ textField: { size: 'small', fullWidth: true } }}
+                    />
+                  </Grid2>
+                </Grid2>
+              ) : (
+                <Typography>{dayjs(data.endDateTime).format('YYYY/MM/DD HH:mm')}</Typography>
+              )}
+            </Grid2>
+
+            <Grid2 xs={12}>
+              <Typography variant="caption">請假時數</Typography>
+              <Typography>{data.leaveHours} 小時</Typography>
+            </Grid2>
+            <Grid2 xs={12}>
+              <Typography variant="caption">請假原因</Typography>
+              {isEditing ? (
+                <TextField
+                  fullWidth
+                  value={data.reason}
+                  onChange={(e) => handleChange('reason', e.target.value)}
+                  multiline
+                  rows={3}
+                  size="small"
+                />
+              ) : (
+                <Typography>{data.reason || '—'}</Typography>
+              )}
+            </Grid2>
+
+            <Grid2 xs={6}>
+              <Typography variant="caption">代理人</Typography>
+              {isEditing ? (
+                <Select
+                  fullWidth
+                  size="small"
+                  value={data.proxyEmployeeCode || ''}
+                  onChange={(e) => handleChange('proxyEmployeeCode', e.target.value)}
+                >
+                  <MenuItem value="">- 請選擇 -</MenuItem>
+                  {proxies.map((p) => (
+                    <MenuItem key={p.employeeCode} value={p.employeeCode}>
+                      {p.employeeName}
+                    </MenuItem>
+                  ))}
+                </Select>
+              ) : (
+                <Typography>{data.proxyEmployeeName || '—'}</Typography>
+              )}
+            </Grid2>
+
+            <Grid2 xs={6}>
+              <Typography variant="caption">審核人</Typography>
+              <Typography>{data.approverEmployeeName || '—'}</Typography>
+            </Grid2>
+
+            <Grid2 xs={12}>
+              <Typography variant="caption">附件</Typography>
+              <Stack direction="row" alignItems="center" spacing={1}>
+                {isEditing && (
+                  <Button variant="outlined" component="label" size="small">
+                    重新上傳
+                    <input type="file" hidden onChange={handleFileChange} />
+                  </Button>
+                )}
+                <Typography variant="body2">{fileName || data.fileName || '未選擇檔案'}</Typography>
+              </Stack>
+            </Grid2>
+          </Grid2>
+        </LocalizationProvider>
       </DialogContent>
       <DialogActions sx={{ justifyContent: 'flex-end' }}>
         {!isEditing ? (

--- a/src/pages/LeaveDetailDialog.tsx
+++ b/src/pages/LeaveDetailDialog.tsx
@@ -1,4 +1,3 @@
-// LeaveDetailDialog.tsx
 import { useEffect, useState } from 'react';
 import {
   Dialog,
@@ -10,15 +9,15 @@ import {
   TextField,
   Select,
   MenuItem,
-  Stack,
 } from '@mui/material';
-import Grid2 from '@mui/material/Grid';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider, DatePicker, TimePicker } from '@mui/x-date-pickers';
+import { LocalizationProvider } from '@mui/x-date-pickers';
 import dayjs, { Dayjs } from 'dayjs';
-import { getProxies } from '../api/employee';
 import { uploadFile, getLeaveDetail, updateLeave } from '../api/leave';
-import { getTaiwanHolidays } from '../api/holiday';
+import FileUploadButton from '../components/FileUploadButton';
+import LeaveTimePickerGroup from '../components/LeaveTimePickerGroup';
+import { useLeaveHoursCalculator } from '../hooks/useLeaveHoursCalculator';
+import { useProxiesAndHolidays } from '../hooks/useProxiesAndHolidays';
 
 interface Props {
   open: boolean;
@@ -30,85 +29,60 @@ interface Props {
 export default function LeaveDetailDialog({ open, onClose, leaveId, onSuccess }: Props) {
   const [data, setData] = useState<any>(null);
   const [isEditing, setIsEditing] = useState(false);
-  const [proxies, setProxies] = useState<any[]>([]);
   const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState('');
-  const [holidays, setHolidays] = useState<string[]>([]);
   const [startDate, setStartDate] = useState<Dayjs | null>(null);
   const [startTime, setStartTime] = useState<Dayjs | null>(null);
   const [endDate, setEndDate] = useState<Dayjs | null>(null);
   const [endTime, setEndTime] = useState<Dayjs | null>(null);
+  const [start, setStart] = useState<Dayjs | null>(null);
+  const [end, setEnd] = useState<Dayjs | null>(null);
+
+  const { proxies, holidays } = useProxiesAndHolidays();
+  const leaveHours = useLeaveHoursCalculator(start, end, holidays);
 
   useEffect(() => {
     if (leaveId && open) {
-      Promise.all([getLeaveDetail(leaveId), getProxies(), getTaiwanHolidays()]).then(
-        ([detail, proxyList, holidayList]) => {
-          setData(detail);
-          setProxies(proxyList);
-          setHolidays(holidayList.map((d) => dayjs(d).format('YYYY-MM-DD')));
-          setIsEditing(false);
-          setFileName(detail.fileName || '');
-          const s = dayjs(detail.startDateTime);
-          const e = dayjs(detail.endDateTime);
-          setStartDate(s.startOf('day'));
-          setStartTime(s);
-          setEndDate(e.startOf('day'));
-          setEndTime(e);
-        },
-      );
+      getLeaveDetail(leaveId).then((detail) => {
+        setData(detail);
+        setIsEditing(false);
+        setFileName(detail.fileName || '');
+        const s = dayjs(detail.startDateTime);
+        const e = dayjs(detail.endDateTime);
+        setStartDate(s.startOf('day'));
+        setStartTime(s);
+        setEndDate(e.startOf('day'));
+        setEndTime(e);
+        setStart(s);
+        setEnd(e);
+      });
     }
   }, [leaveId, open]);
 
-  const disableDate = (date: Dayjs) => {
-    const day = date.day();
-    return day === 0 || day === 6 || holidays.includes(date.format('YYYY-MM-DD'));
-  };
-
   useEffect(() => {
-    if (startDate && startTime && endDate && endTime && data) {
-      const start = startDate.hour(startTime.hour()).minute(startTime.minute());
-      const end = endDate.hour(endTime.hour()).minute(endTime.minute());
-
-      const updated = { ...data };
-      updated.startDateTime = start.toISOString();
-      updated.endDateTime = end.toISOString();
-      updated.leaveHours = calculateLeaveHours(start.toISOString(), end.toISOString());
-      setData(updated);
+    if (startDate && startTime && endDate && endTime) {
+      const s = startDate.hour(startTime.hour()).minute(startTime.minute());
+      const e = endDate.hour(endTime.hour()).minute(endTime.minute());
+      setStart(s);
+      setEnd(e);
     }
   }, [startDate, startTime, endDate, endTime]);
 
-  const calculateLeaveHours = (startStr: string, endStr: string) => {
-    const start = dayjs(startStr);
-    const end = dayjs(endStr);
-    if (!start.isValid() || !end.isValid() || !end.isAfter(start)) return 0;
-
-    let hours = 0;
-    let curr = start.startOf('hour');
-
-    while (curr.isBefore(end)) {
-      const isHoliday = holidays.includes(curr.format('YYYY-MM-DD'));
-      const isWeekend = curr.day() === 0 || curr.day() === 6;
-      if (!isHoliday && !isWeekend) {
-        const hour = curr.hour();
-        if (hour >= 9 && hour < 18) hours += 1;
-      }
-      curr = curr.add(1, 'hour');
+  useEffect(() => {
+    if (data && leaveHours !== data.leaveHours) {
+      setData({ ...data, leaveHours });
     }
-    return hours;
-  };
+  }, [leaveHours]);
 
   const handleChange = (field: string, value: any) => {
     const updated = { ...data, [field]: value };
     setData(updated);
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selected = e.target.files?.[0] || null;
-    setFile(selected);
-    setFileName(selected?.name || '');
-  };
-
   const handleSubmit = async () => {
+    const formattedStart = start?.format('YYYY-MM-DDTHH:mm:ss');
+    const formattedEnd = end?.format('YYYY-MM-DDTHH:mm:ss');
+
     let uploadedPath = data.filePath;
     let uploadedName = data.fileName;
     if (file) {
@@ -118,9 +92,9 @@ export default function LeaveDetailDialog({ open, onClose, leaveId, onSuccess }:
     }
     const payload = {
       leaveTypeId: data.leaveTypeId,
-      startDateTime: data.startDateTime,
-      endDateTime: data.endDateTime,
-      leaveHours: data.leaveHours,
+      startDateTime: formattedStart,
+      endDateTime: formattedEnd,
+      leaveHours,
       reason: data.reason,
       proxyEmployeeCode: data.proxyEmployeeCode ?? '',
       filePath: uploadedPath,
@@ -138,137 +112,102 @@ export default function LeaveDetailDialog({ open, onClose, leaveId, onSuccess }:
       <DialogTitle>請假紀錄詳情</DialogTitle>
       <DialogContent dividers>
         <LocalizationProvider dateAdapter={AdapterDayjs}>
-          <Grid2 container columns={12} spacing={2}>
-            <Grid2 xs={6}>
-              <Typography variant="caption">申請人</Typography>
-              <Typography>{data.employeeName}</Typography>
-            </Grid2>
-            <Grid2 xs={6}>
-              <Typography variant="caption">假別</Typography>
-              <Typography>{data.leaveTypeName}</Typography>
-            </Grid2>
+          <Typography variant="caption">申請人</Typography>
+          <Typography gutterBottom>{data.employeeName}</Typography>
 
-            <Grid2 xs={12}>
-              <Typography variant="caption">開始時間</Typography>
-              {isEditing ? (
-                <Grid2 container columns={12} spacing={2}>
-                  <Grid2 xs={6}>
-                    <DatePicker
-                      label="開始日期"
-                      value={startDate}
-                      onChange={setStartDate}
-                      shouldDisableDate={disableDate}
-                      slotProps={{ textField: { size: 'small', fullWidth: true } }}
-                    />
-                  </Grid2>
-                  <Grid2 xs={6}>
-                    <TimePicker
-                      label="開始時間"
-                      ampm={false}
-                      views={['hours']}
-                      minTime={dayjs().hour(9)}
-                      maxTime={dayjs().hour(18)}
-                      value={startTime}
-                      onChange={setStartTime}
-                      slotProps={{ textField: { size: 'small', fullWidth: true } }}
-                    />
-                  </Grid2>
-                </Grid2>
-              ) : (
-                <Typography>{dayjs(data.startDateTime).format('YYYY/MM/DD HH:mm')}</Typography>
-              )}
-            </Grid2>
+          <Typography variant="caption">假別</Typography>
+          <Typography gutterBottom>{data.leaveTypeName}</Typography>
 
-            <Grid2 xs={12}>
-              <Typography variant="caption">結束時間</Typography>
-              {isEditing ? (
-                <Grid2 container columns={12} spacing={2}>
-                  <Grid2 xs={6}>
-                    <DatePicker
-                      label="結束日期"
-                      value={endDate}
-                      onChange={setEndDate}
-                      shouldDisableDate={disableDate}
-                      slotProps={{ textField: { size: 'small', fullWidth: true } }}
-                    />
-                  </Grid2>
-                  <Grid2 xs={6}>
-                    <TimePicker
-                      label="結束時間"
-                      ampm={false}
-                      views={['hours']}
-                      minTime={dayjs().hour(9)}
-                      maxTime={dayjs().hour(18)}
-                      value={endTime}
-                      onChange={setEndTime}
-                      slotProps={{ textField: { size: 'small', fullWidth: true } }}
-                    />
-                  </Grid2>
-                </Grid2>
-              ) : (
-                <Typography>{dayjs(data.endDateTime).format('YYYY/MM/DD HH:mm')}</Typography>
-              )}
-            </Grid2>
+          <Typography variant="caption">開始時間</Typography>
+          {isEditing ? (
+            <LeaveTimePickerGroup
+              label=""
+              date={startDate}
+              time={startTime}
+              setDate={setStartDate}
+              setTime={setStartTime}
+              disableDate={(d) =>
+                holidays.includes(d.format('YYYY-MM-DD')) || d.day() === 0 || d.day() === 6
+              }
+            />
+          ) : (
+            <Typography gutterBottom>
+              {dayjs(data.startDateTime).format('YYYY/MM/DD HH:mm')}
+            </Typography>
+          )}
 
-            <Grid2 xs={12}>
-              <Typography variant="caption">請假時數</Typography>
-              <Typography>{data.leaveHours} 小時</Typography>
-            </Grid2>
-            <Grid2 xs={12}>
-              <Typography variant="caption">請假原因</Typography>
-              {isEditing ? (
-                <TextField
-                  fullWidth
-                  value={data.reason}
-                  onChange={(e) => handleChange('reason', e.target.value)}
-                  multiline
-                  rows={3}
-                  size="small"
-                />
-              ) : (
-                <Typography>{data.reason || '—'}</Typography>
-              )}
-            </Grid2>
+          <Typography variant="caption">結束時間</Typography>
+          {isEditing ? (
+            <LeaveTimePickerGroup
+              label=""
+              date={endDate}
+              time={endTime}
+              setDate={setEndDate}
+              setTime={setEndTime}
+              disableDate={(d) =>
+                holidays.includes(d.format('YYYY-MM-DD')) || d.day() === 0 || d.day() === 6
+              }
+            />
+          ) : (
+            <Typography gutterBottom>
+              {dayjs(data.endDateTime).format('YYYY/MM/DD HH:mm')}
+            </Typography>
+          )}
 
-            <Grid2 xs={6}>
-              <Typography variant="caption">代理人</Typography>
-              {isEditing ? (
-                <Select
-                  fullWidth
-                  size="small"
-                  value={data.proxyEmployeeCode || ''}
-                  onChange={(e) => handleChange('proxyEmployeeCode', e.target.value)}
-                >
-                  <MenuItem value="">- 請選擇 -</MenuItem>
-                  {proxies.map((p) => (
-                    <MenuItem key={p.employeeCode} value={p.employeeCode}>
-                      {p.employeeName}
-                    </MenuItem>
-                  ))}
-                </Select>
-              ) : (
-                <Typography>{data.proxyEmployeeName || '—'}</Typography>
-              )}
-            </Grid2>
+          <Typography variant="caption">請假時數</Typography>
+          <Typography gutterBottom>{leaveHours} 小時</Typography>
 
-            <Grid2 xs={6}>
-              <Typography variant="caption">審核人</Typography>
-              <Typography>{data.approverEmployeeName || '—'}</Typography>
-            </Grid2>
+          <Typography variant="caption">請假原因</Typography>
+          {isEditing ? (
+            <TextField
+              fullWidth
+              value={data.reason}
+              onChange={(e) => handleChange('reason', e.target.value)}
+              multiline
+              rows={3}
+              size="small"
+              sx={{ mb: 2 }}
+            />
+          ) : (
+            <Typography gutterBottom>{data.reason || '—'}</Typography>
+          )}
 
-            <Grid2 xs={12}>
-              <Typography variant="caption">附件</Typography>
-              <Stack direction="row" alignItems="center" spacing={1}>
-                {isEditing && (
-                  <Button variant="outlined" component="label" size="small">
-                    重新上傳
-                    <input type="file" hidden onChange={handleFileChange} />
-                  </Button>
-                )}
-                <Typography variant="body2">{fileName || data.fileName || '未選擇檔案'}</Typography>
-              </Stack>
-            </Grid2>
-          </Grid2>
+          <Typography variant="caption">代理人</Typography>
+          {isEditing ? (
+            <Select
+              fullWidth
+              size="small"
+              value={data.proxyEmployeeCode || ''}
+              onChange={(e) => handleChange('proxyEmployeeCode', e.target.value)}
+              sx={{ mb: 2 }}
+            >
+              <MenuItem value="">- 請選擇 -</MenuItem>
+              {proxies.map((p) => (
+                <MenuItem key={p.employeeCode} value={p.employeeCode}>
+                  {p.employeeName}
+                </MenuItem>
+              ))}
+            </Select>
+          ) : (
+            <Typography gutterBottom>{data.proxyEmployeeName || '—'}</Typography>
+          )}
+
+          <Typography variant="caption">審核人</Typography>
+          <Typography gutterBottom>{data.approverEmployeeName || '—'}</Typography>
+
+          <Typography variant="caption">附件</Typography>
+          {isEditing ? (
+            <FileUploadButton
+              file={file}
+              fileName={fileName}
+              onFileChange={(f) => {
+                setFile(f);
+                setFileName(f?.name || '');
+              }}
+            />
+          ) : (
+            <Typography gutterBottom>{fileName || data.fileName || '未選擇檔案'}</Typography>
+          )}
         </LocalizationProvider>
       </DialogContent>
       <DialogActions sx={{ justifyContent: 'flex-end' }}>

--- a/src/pages/LeavePage.tsx
+++ b/src/pages/LeavePage.tsx
@@ -74,24 +74,23 @@ export default function LeavePage() {
 
   useEffect(() => {
     if (start && end && end.isAfter(start)) {
-      const startDay = start.startOf('day');
-      const endDay = end.startOf('day');
-      const dayDiff = endDay.diff(startDay, 'day');
-
       let hours = 0;
-      if (dayDiff === 0) {
-        const startHour = Math.max(start.hour(), 9);
-        const endHour = Math.min(end.hour(), 18);
-        hours = endHour > startHour ? endHour - startHour : 0;
-      } else {
-        const firstDayHours = 18 - Math.max(start.hour(), 9);
-        const lastDayHours = Math.min(end.hour(), 18) - 9;
-        const fullDays = dayDiff - 1;
-        hours =
-          (firstDayHours > 0 ? firstDayHours : 0) +
-          (fullDays > 0 ? fullDays * 8 : 0) +
-          (lastDayHours > 0 ? lastDayHours : 0);
+      let curr = start.startOf('hour');
+
+      while (curr.isBefore(end)) {
+        const isHoliday = holidays.includes(curr.format('YYYY-MM-DD'));
+        const isWeekend = curr.day() === 0 || curr.day() === 6;
+
+        if (!isHoliday && !isWeekend) {
+          const startHour = curr.hour();
+          if (startHour >= 9 && startHour < 18) {
+            hours += 1;
+          }
+        }
+
+        curr = curr.add(1, 'hour');
       }
+
       setLeaveHours(hours);
     } else if (start && end && (end.isSame(start) || end.isBefore(start))) {
       setErrorMsg('結束時間不能早於或等於開始時間，請重新選擇');
@@ -99,7 +98,7 @@ export default function LeavePage() {
       setEndDate(null);
       setLeaveHours(0);
     }
-  }, [start, end]);
+  }, [start, end, holidays]);
 
   const handleFileUpload = async () => {
     if (!file) return;

--- a/src/pages/LeavePage.tsx
+++ b/src/pages/LeavePage.tsx
@@ -1,33 +1,28 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import { getLeaveBalance, uploadFile, applyLeave } from '../api/leave';
-import { getProxies, getSupervisor } from '../api/employee';
-import { getTaiwanHolidays } from '../api/holiday';
-import { EmployeeDTO } from '../types/Employee';
 import {
   Box,
-  Button,
-  TextField,
-  Radio,
-  RadioGroup,
-  FormControlLabel,
-  FormControl,
-  FormLabel,
   Typography,
-  Select,
-  MenuItem,
   Alert,
+  Button,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
   Stack,
-  Grid,
+  TextField,
+  Select,
+  MenuItem,
 } from '@mui/material';
-import { LocalizationProvider, DatePicker, TimePicker } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers';
 import { CheckCircle } from 'lucide-react';
+import { getLeaveBalance, uploadFile, applyLeave } from '../api/leave';
+import { useLeaveHoursCalculator } from '../hooks/useLeaveHoursCalculator';
+import { useProxiesAndHolidays } from '../hooks/useProxiesAndHolidays';
+import LeaveTimePickerGroup from '../components/LeaveTimePickerGroup';
+import FileUploadButton from '../components/FileUploadButton';
+import LeaveTypeRadioGroup from '../components/LeaveTypeRadioGroup';
 
 export default function LeavePage() {
   const [leaveTypeId, setLeaveTypeId] = useState(1);
@@ -37,30 +32,17 @@ export default function LeavePage() {
   const [endTime, setEndTime] = useState<Dayjs | null>(null);
   const [start, setStart] = useState<Dayjs | null>(null);
   const [end, setEnd] = useState<Dayjs | null>(null);
-  const [leaveHours, setLeaveHours] = useState(0);
-  const [maxHours, setMaxHours] = useState(0);
   const [reason, setReason] = useState('');
-  const [proxies, setProxies] = useState<EmployeeDTO[]>([]);
   const [proxyCode, setProxyCode] = useState('');
-  const [supervisor, setSupervisor] = useState('');
   const [file, setFile] = useState<File | null>(null);
-  const [filePath, setFilePath] = useState('');
   const [fileName, setFileName] = useState('');
+  const [filePath, setFilePath] = useState('');
   const [successData, setSuccessData] = useState<any>(null);
   const [errorMsg, setErrorMsg] = useState('');
-  const [holidays, setHolidays] = useState<string[]>([]);
+  const [maxHours, setMaxHours] = useState(0);
 
-  useEffect(() => {
-    getSupervisor().then((name) => setSupervisor(name || ''));
-    getProxies().then(setProxies);
-    getTaiwanHolidays().then((dates) => {
-      setHolidays(dates.map((d) => dayjs(d).format('YYYY-MM-DD')));
-    });
-  }, []);
-
-  useEffect(() => {
-    getLeaveBalance(leaveTypeId).then(setMaxHours);
-  }, [leaveTypeId]);
+  const { proxies, holidays } = useProxiesAndHolidays();
+  const leaveHours = useLeaveHoursCalculator(start, end, holidays);
 
   useEffect(() => {
     if (startDate && startTime && endDate && endTime) {
@@ -68,107 +50,77 @@ export default function LeavePage() {
       const e = endDate.hour(endTime.hour()).minute(endTime.minute());
       setStart(s);
       setEnd(e);
-      setErrorMsg('');
     }
   }, [startDate, startTime, endDate, endTime]);
 
   useEffect(() => {
-    if (start && end && end.isAfter(start)) {
-      let hours = 0;
-      let curr = start.startOf('hour');
-
-      while (curr.isBefore(end)) {
-        const isHoliday = holidays.includes(curr.format('YYYY-MM-DD'));
-        const isWeekend = curr.day() === 0 || curr.day() === 6;
-
-        if (!isHoliday && !isWeekend) {
-          const startHour = curr.hour();
-          if (startHour >= 9 && startHour < 18) {
-            hours += 1;
-          }
-        }
-
-        curr = curr.add(1, 'hour');
-      }
-
-      setLeaveHours(hours);
-    } else if (start && end && (end.isSame(start) || end.isBefore(start))) {
-      setErrorMsg('結束時間不能早於或等於開始時間，請重新選擇');
-      setEndTime(null);
-      setEndDate(null);
-      setLeaveHours(0);
-    }
-  }, [start, end, holidays]);
-
-  const handleFileUpload = async () => {
-    if (!file) return;
-    const result = await uploadFile(file);
-    setFilePath(result.uniqueFileName);
-    setFileName(result.originalFileName);
-  };
+    getLeaveBalance(leaveTypeId).then(setMaxHours);
+  }, [leaveTypeId]);
 
   const handleSubmit = async () => {
     setErrorMsg('');
+
     if (!start || !end || leaveHours === 0 || leaveHours > maxHours) {
       setErrorMsg('請確認請假時間與剩餘時數');
       return;
     }
-    await handleFileUpload();
+
+    let uploadedPath = '';
+    let uploadedName = '';
+
+    if (file) {
+      const result = await uploadFile(file);
+      uploadedPath = result.uniqueFileName;
+      uploadedName = result.originalFileName;
+    }
+
+    const formattedStart = start?.format('YYYY-MM-DDTHH:mm:ss');
+    const formattedEnd = end?.format('YYYY-MM-DDTHH:mm:ss');
 
     try {
       const payload = {
         leaveTypeId,
-        startDateTime: start.toISOString(),
-        endDateTime: end.toISOString(),
+        startDateTime: formattedStart,
+        endDateTime: formattedEnd,
         leaveHours,
         reason,
         proxyEmployeeCode: proxyCode,
-        filePath,
-        fileName,
+        filePath: uploadedPath,
+        fileName: uploadedName,
       };
       const res = await applyLeave(payload);
       setSuccessData(res);
-      setLeaveTypeId(1);
-      setStartDate(null);
-      setStartTime(null);
-      setEndDate(null);
-      setEndTime(null);
-      setStart(null);
-      setEnd(null);
-      setLeaveHours(0);
-      setReason('');
-      setProxyCode('');
-      setFile(null);
-      setFilePath('');
-      setFileName('');
+      resetForm();
     } catch (err: any) {
       const apiMsg = err?.response?.data?.msg || '請假申請失敗，請稍後再試';
       setErrorMsg(apiMsg);
     }
   };
 
-  const disableDate = (date: dayjs.Dayjs) => {
-    const day = date.day();
-    return day === 0 || day === 6 || holidays.includes(date.format('YYYY-MM-DD'));
+  const resetForm = () => {
+    setLeaveTypeId(1);
+    setStartDate(null);
+    setStartTime(null);
+    setEndDate(null);
+    setEndTime(null);
+    setStart(null);
+    setEnd(null);
+    setReason('');
+    setProxyCode('');
+    setFile(null);
+    setFileName('');
+    setFilePath('');
   };
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <Box
-        sx={{
-          width: '100%',
-          padding: '1rem',
-          boxSizing: 'border-box',
-          display: 'flex',
-          justifyContent: 'center',
-        }}
-      >
+      <Box sx={{ width: '100%', p: 2, display: 'flex', justifyContent: 'center' }}>
         <Box
           sx={{
             width: '100%',
-            maxWidth: '1200px',
-            padding: 3,
-            backgroundColor: 'white',
+            maxWidth: 1000,
+            p: 3,
+            bgcolor: 'white',
             borderRadius: 2,
             boxShadow: 3,
           }}
@@ -183,160 +135,100 @@ export default function LeavePage() {
             </Alert>
           )}
 
-          <FormControl fullWidth size="small" sx={{ mb: 2 }}>
-            <FormLabel>假別</FormLabel>
-            <RadioGroup
-              row
-              value={leaveTypeId}
-              onChange={(e) => setLeaveTypeId(Number(e.target.value))}
-            >
-              <FormControlLabel
-                value={1}
-                sx={{ color: 'text.primary' }}
-                control={<Radio />}
-                label="特休"
-              />
-              <FormControlLabel
-                value={2}
-                sx={{ color: 'text.primary' }}
-                control={<Radio />}
-                label="病假"
-              />
-              <FormControlLabel
-                value={3}
-                sx={{ color: 'text.primary' }}
-                control={<Radio />}
-                label="事假"
-              />
-            </RadioGroup>
-          </FormControl>
+          <LeaveTypeRadioGroup leaveTypeId={leaveTypeId} setLeaveTypeId={setLeaveTypeId} />
 
-          <FormLabel>開始時間</FormLabel>
-          <Grid container spacing={2} sx={{ mb: 1, mt: 0.5 }}>
-            <Grid item xs={6}>
-              <DatePicker
-                label="開始日期"
-                value={startDate}
-                onChange={setStartDate}
-                shouldDisableDate={disableDate}
-                slotProps={{ textField: { size: 'small', fullWidth: true } }}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <TimePicker
-                ampm={false}
-                views={['hours']}
-                format="HH:mm"
-                label="開始時間"
-                value={startTime}
-                onChange={setStartTime}
-                minTime={dayjs().hour(9)}
-                maxTime={dayjs().hour(18)}
-                slotProps={{ textField: { size: 'small', fullWidth: true } }}
-              />
-            </Grid>
-          </Grid>
+          <LeaveTimePickerGroup
+            label="開始時間"
+            date={startDate}
+            time={startTime}
+            setDate={setStartDate}
+            setTime={setStartTime}
+            disableDate={(d) =>
+              holidays.includes(d.format('YYYY-MM-DD')) || d.day() === 0 || d.day() === 6
+            }
+          />
 
-          <FormLabel>結束時間</FormLabel>
-          <Grid container spacing={2} sx={{ mb: 2, mt: 0.5 }}>
-            <Grid item xs={6}>
-              <DatePicker
-                label="結束日期"
-                value={endDate}
-                onChange={setEndDate}
-                shouldDisableDate={disableDate}
-                slotProps={{ textField: { size: 'small', fullWidth: true } }}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <TimePicker
-                ampm={false}
-                views={['hours']}
-                format="HH:mm"
-                label="結束時間"
-                value={endTime}
-                onChange={setEndTime}
-                minTime={dayjs().hour(9)}
-                maxTime={dayjs().hour(18)}
-                slotProps={{ textField: { size: 'small', fullWidth: true } }}
-              />
-            </Grid>
-          </Grid>
+          <LeaveTimePickerGroup
+            label="結束時間"
+            date={endDate}
+            time={endTime}
+            setDate={setEndDate}
+            setTime={setEndTime}
+            disableDate={(d) =>
+              holidays.includes(d.format('YYYY-MM-DD')) || d.day() === 0 || d.day() === 6
+            }
+          />
 
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          <Typography sx={{ mb: 2 }} color="text.secondary">
             請假時數：{leaveHours} 小時（上限 {maxHours} 小時）
           </Typography>
 
-          <FormLabel>代理人</FormLabel>
-          <FormControl fullWidth size="small" sx={{ mb: 2, mt: 0.5 }}>
-            <Select value={proxyCode} onChange={(e) => setProxyCode(e.target.value)}>
-              <MenuItem value="">- Select -</MenuItem>
-              {proxies.map((p) => (
-                <MenuItem key={p.employeeCode} value={p.employeeCode}>
-                  {p.employeeName}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          <Typography variant="body2" color="text.primary" sx={{ mb: 2 }}>
-            主管：{supervisor}
-          </Typography>
-
-          <FormLabel>請假事由</FormLabel>
           <TextField
+            label="請假原因"
+            fullWidth
             value={reason}
             onChange={(e) => setReason(e.target.value)}
-            fullWidth
             multiline
             rows={3}
             size="small"
-            sx={{ mb: 2, mt: 0.5 }}
+            sx={{ mb: 2 }}
           />
 
-          <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 2 }}>
-            <Button variant="outlined" component="label" size="small">
-              上傳附件
-              <input
-                type="file"
-                hidden
-                onChange={(e) => {
-                  setFile(e.target.files?.[0] || null);
-                  setFileName(e.target.files?.[0]?.name || '');
-                }}
-              />
-            </Button>
-            <Typography variant="body2" color="text.secondary">
-              {fileName || '未選擇檔案'}
-            </Typography>
-          </Stack>
+          <Select
+            value={proxyCode}
+            onChange={(e) => setProxyCode(e.target.value)}
+            fullWidth
+            size="small"
+            displayEmpty
+            sx={{ mb: 2 }}
+          >
+            <MenuItem value="">- 選擇代理人 -</MenuItem>
+            {proxies.map((p) => (
+              <MenuItem key={p.employeeCode} value={p.employeeCode}>
+                {p.employeeName}
+              </MenuItem>
+            ))}
+          </Select>
 
-          <Button variant="contained" color="primary" fullWidth onClick={handleSubmit}>
-            立即申請請假
+          <FileUploadButton
+            file={file}
+            fileName={fileName}
+            onFileChange={(f) => {
+              setFile(f);
+              setFileName(f?.name || '');
+            }}
+          />
+
+          <Button
+            fullWidth
+            variant="contained"
+            color="primary"
+            sx={{ mt: 3 }}
+            onClick={handleSubmit}
+          >
+            送出請假申請
           </Button>
 
           <Dialog open={!!successData} onClose={() => setSuccessData(null)}>
-            <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <CheckCircle style={{ color: 'green' }} />
-              <Typography variant="h6">請假申請成功</Typography>
+            <DialogTitle>
+              <CheckCircle style={{ color: 'green', marginRight: 8 }} />
+              請假申請成功
             </DialogTitle>
             <DialogContent dividers>
               <Stack spacing={1}>
                 <Typography>假單編號：{successData?.leaveApplicationId}</Typography>
                 <Typography>假別：{successData?.leaveTypeName}</Typography>
                 <Typography>
-                  時間：{dayjs(successData?.startDateTime).format('YYYY-MM-DD HH:mm')} ～{' '}
+                  時間：{dayjs(successData?.startDateTime).format('YYYY-MM-DD HH:mm')} ～
                   {dayjs(successData?.endDateTime).format('YYYY-MM-DD HH:mm')}
                 </Typography>
                 <Typography>總時數：{successData?.leaveHours} 小時</Typography>
                 <Typography>代理人：{successData?.proxyEmployeeName || '—'}</Typography>
-                <Typography>主管：{supervisor || '—'}</Typography>
                 <Typography>事由：{successData?.reason || '—'}</Typography>
-                <Typography>附件：{successData?.fileName || '—'}</Typography>
               </Stack>
             </DialogContent>
             <DialogActions>
-              <Button onClick={() => setSuccessData(null)} variant="contained" color="primary">
+              <Button onClick={() => setSuccessData(null)} variant="contained">
                 關閉
               </Button>
             </DialogActions>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -10,7 +10,7 @@ function LoginPage({ setToken }: { setToken: (t: string) => void }) {
 
   const handleLogin = async () => {
     try {
-      setErrorMsg(''); // 清除前一次錯誤訊息
+      setErrorMsg('');
       const data = await login(employeeCode, password);
       localStorage.setItem('jwtToken', data.data.token);
       setToken(data.data.token);

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -5,15 +5,6 @@ import {
   Typography,
   Grid,
   Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Chip,
-  Link,
-  Tooltip,
   FormControl,
   InputLabel,
   MenuItem,
@@ -22,7 +13,8 @@ import {
 } from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { getLeaveBalance, getLeaveHistory, downloadAttachment } from '../api/leave';
+import { getLeaveBalance, getLeaveHistory } from '../api/leave';
+import LeaveTable from '../components/LeaveTable';
 
 const leaveTypes = [
   { id: 1, name: '特休假' },
@@ -37,27 +29,6 @@ const statuses = [
   { value: '已拒絕', label: '已拒絕' },
   { value: '已取消', label: '已取消' },
 ];
-
-const renderCell = (value?: string) => value?.replace('T', ' ') || '—';
-
-const getStatusChip = (status: string) => {
-  switch (status) {
-    case 'PENDING':
-    case '待審核':
-      return <Chip label="待審核" color="default" />;
-    case 'APPROVED':
-    case '已核准':
-      return <Chip label="已核准" color="success" />;
-    case 'REJECTED':
-    case '已拒絕':
-      return <Chip label="已拒絕" color="error" />;
-    case 'CANCELED':
-    case '已取消':
-      return <Chip label="已取消" color="default" />;
-    default:
-      return <Chip label={status} />;
-  }
-};
 
 export default function MainPage() {
   const [balances, setBalances] = useState<Record<number, string>>({});
@@ -98,21 +69,13 @@ export default function MainPage() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <Box
-        sx={{
-          width: '100%',
-          padding: '1rem',
-          boxSizing: 'border-box',
-          display: 'flex',
-          justifyContent: 'center',
-        }}
-      >
+      <Box sx={{ width: '100%', p: 2, display: 'flex', justifyContent: 'center' }}>
         <Box
           sx={{
             width: '100%',
             maxWidth: '1200px',
-            padding: 3,
-            backgroundColor: 'white',
+            p: 3,
+            bgcolor: 'white',
             borderRadius: 2,
             boxShadow: 3,
           }}
@@ -173,80 +136,14 @@ export default function MainPage() {
             </Grid>
           </Grid>
 
-          <TableContainer component={Paper}>
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>申請時間</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>假別</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>審核時間</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>請假時間</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>結束時間</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>請假時數</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>請假原因</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>主管留言</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>代理人員編</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>代理人姓名</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>附件</TableCell>
-                  <TableCell sx={{ whiteSpace: 'nowrap' }}>申請狀態</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {filteredHistory.map((row) => (
-                  <TableRow
-                    key={row.applicationId}
-                    hover
-                    onClick={() => {
-                      setSelectedId(row.applicationId);
-                      setDialogOpen(true);
-                    }}
-                    style={{ cursor: 'pointer' }}
-                  >
-                    <TableCell>{row.applicationDateTime?.split('T')[0] || '—'}</TableCell>
-                    <TableCell>{row.leaveTypeName}</TableCell>
-                    <TableCell>{renderCell(row.approvalDatetime)}</TableCell>
-                    <TableCell>{renderCell(row.startDateTime)}</TableCell>
-                    <TableCell>{renderCell(row.endDateTime)}</TableCell>
-                    <TableCell>
-                      {row.leaveHours} 小時 ({(row.leaveHours / 8).toFixed(1)} 天)
-                    </TableCell>
-                    <TableCell>
-                      <Tooltip title={row.reason || ''}>
-                        <Typography
-                          sx={{
-                            maxWidth: 200,
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                          }}
-                        >
-                          {row.reason || '—'}
-                        </Typography>
-                      </Tooltip>
-                    </TableCell>
-                    <TableCell>{row.approvalReason || '—'}</TableCell>
-                    <TableCell>{row.proxyEmployeeCode || '—'}</TableCell>
-                    <TableCell>{row.proxyEmployeeName || '—'}</TableCell>
-                    <TableCell>
-                      {row.fileName ? (
-                        <Link
-                          href={downloadAttachment(row.fileName)}
-                          target="_blank"
-                          rel="noopener"
-                        >
-                          📎
-                        </Link>
-                      ) : (
-                        '—'
-                      )}
-                    </TableCell>
-                    <TableCell>{getStatusChip(row.status)}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-          {/* 詳情 Dialog */}
+          <LeaveTable
+            data={filteredHistory}
+            onRowClick={(id) => {
+              setSelectedId(id);
+              setDialogOpen(true);
+            }}
+          />
+
           <LeaveDetailDialog
             open={dialogOpen}
             leaveId={selectedId}

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -1,0 +1,11 @@
+import { Dayjs } from 'dayjs';
+
+export function isHoliday(date: Dayjs, holidays: string[]): boolean {
+  const isWeekend = date.day() === 0 || date.day() === 6;
+  const isInHolidayList = holidays.includes(date.format('YYYY-MM-DD'));
+  return isWeekend || isInHolidayList;
+}
+
+export function disableDate(holidays: string[]) {
+  return (date: Dayjs) => isHoliday(date, holidays);
+}

--- a/src/utils/formats.ts
+++ b/src/utils/formats.ts
@@ -1,0 +1,13 @@
+import dayjs from 'dayjs';
+
+export function formatDateTime(value?: string | null): string {
+  return value ? dayjs(value).format('YYYY-MM-DD HH') + '點' : '—';
+}
+
+export function formatDateOnly(value: string | Date): string {
+  return dayjs(value).format('YYYY-MM-DD');
+}
+
+export function formatHourOnly(value?: string | Date | null): string {
+  return value ? dayjs(value).format('HH') + '點' : '—';
+}


### PR DESCRIPTION
改動如下：
1. 原本計算請假時數如果有跨過假日或週末照算，現在修正了
2. 把可重用元件抽出來：LeaveTimePickerGroup、LeaveTypeRadioGroup、FileUploadButton、LeaveStatusChip
3. 新增 hooks：useLeaveHoursCalculator、useProxiesAndHolidays，簡化頁面邏輯
4. 重構 LeavePage 與 LeaveDetailDialog，統一表單結構與互動邏輯
5. 修正時區錯誤，避免請假時間誤送為 UTC
6. LeaveTable 表格調整欄寬與 Tooltip 顯示效果，提升可讀性
7.  加入格式化工具函數 formatDateTime、formatHourOnly，統一日期格式處理
