### PR TITLE
feat(LeaveManage): display applicant name and refresh table after approval

### DIFF
--- a/src/pages/LeaveManage.tsx
+++ b/src/pages/LeaveManage.tsx
@@ -20,6 +20,11 @@ const LeaveManage = () => {
   const [selectedId, setSelectedId] = useState<any>(null);
   const [approvalReason, setApprovalReason] = useState('');
 
+  const reloadData = async () => {
+    const data = await getAllLeaves();
+    setLeaveData(data);
+  };
+
   // 點擊未審核按鈕時打開 dialog
   const handleOpenDialog = (leaveId: number) => {
     setSelectedId(leaveId);
@@ -27,13 +32,13 @@ const LeaveManage = () => {
   };
 
   // 審核邏輯
-  const handleApprove = () => {
-    // 執行核准邏輯
+  const handleApprove = async () => {
+    await reloadData();
     setDialogOpen(false);
   };
 
-  const handleReject = () => {
-    // 執行拒絕邏輯
+  const handleReject = async () => {
+    await reloadData();
     setDialogOpen(false);
   };
 
@@ -41,11 +46,7 @@ const LeaveManage = () => {
   const downloadAttachment = (fileName: string) => `/api/download/${fileName}`;
 
   useEffect(() => {
-    const fetchData = async () => {
-      const data = await getAllLeaves();
-      setLeaveData(data);
-    };
-    fetchData();
+    reloadData();
   }, []);
 
   const getStatusChip = (status: string, id: number) => {
@@ -83,6 +84,7 @@ const LeaveManage = () => {
         <Table size="small">
           <TableHead>
             <TableRow>
+            <TableCell sx={{ whiteSpace: 'nowrap' }}>員工姓名</TableCell>
               <TableCell sx={{ whiteSpace: 'nowrap' }}>申請時間</TableCell>
               <TableCell sx={{ whiteSpace: 'nowrap' }}>假別</TableCell>
               <TableCell sx={{ whiteSpace: 'nowrap' }}>請假時間</TableCell>
@@ -94,6 +96,7 @@ const LeaveManage = () => {
           <TableBody>
             {leaveData.map((row: any) => (
               <TableRow>
+                <TableCell>{row.employeeName}</TableCell>
                 <TableCell>{renderCell(row.applicationDateTime)}</TableCell>
                 <TableCell>{row.leaveTypeName || '—'}</TableCell>
                 <TableCell>{renderCell(row.startDateTime)}</TableCell>

--- a/src/pages/LeaveManage.tsx
+++ b/src/pages/LeaveManage.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from '@mui/material';
 import { getAllLeaves } from '../api/manager';
+import { downloadAttachment } from '../api/leave';
 import dayjs from 'dayjs';
 
 const LeaveManage = () => {
@@ -41,9 +42,6 @@ const LeaveManage = () => {
     await reloadData();
     setDialogOpen(false);
   };
-
-  // download URL 產生器
-  const downloadAttachment = (fileName: string) => `/api/download/${fileName}`;
 
   useEffect(() => {
     reloadData();

--- a/src/pages/LeaveReviewDialog.tsx
+++ b/src/pages/LeaveReviewDialog.tsx
@@ -44,7 +44,7 @@ const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
     endDateTime: string;
     leaveHours: number;
     reason: string;
-    proxyEmployeeId: number;
+    proxyEmployeeCode: string;
     proxyEmployeeName: string;
     fileName?: string;
     filePath?: string;
@@ -101,7 +101,7 @@ const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
         <Typography>
           請假時數：{data.leaveHours} 小時 ({(data.leaveHours / 8).toFixed(1)} 天)
         </Typography>
-        <Typography>代理人員工編號：{data.proxyEmployeeId}</Typography>
+        <Typography>代理人員工編號：{data.proxyEmployeeCode}</Typography>
         <Typography>代理人姓名：{data.proxyEmployeeName}</Typography>
         <Typography>請假事由：{data.reason}</Typography>
         <Typography>

--- a/src/pages/LeaveReviewDialog.tsx
+++ b/src/pages/LeaveReviewDialog.tsx
@@ -36,7 +36,7 @@ const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
 }) => {
   const [data, setData] = useState<null | {
     leaveApplicationId: number;
-    employeeId: number;
+    employeeCode: string;
     employeeName: string;
     leaveTypeName: string;
     applicationDateTime: string;
@@ -92,7 +92,7 @@ const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
             {error}
           </Alert>
         )}
-        <Typography>員工編號：{data.employeeId}</Typography>
+        <Typography>員工編號：{data.employeeCode}</Typography>
         <Typography>員工姓名：{data.employeeName}</Typography>
         <Typography>假別：{data.leaveTypeName}</Typography>
         <Typography>申請時間：{data.applicationDateTime}</Typography>

--- a/src/pages/LeaveReviewDialog.tsx
+++ b/src/pages/LeaveReviewDialog.tsx
@@ -101,7 +101,7 @@ const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
         <Typography>
           請假時數：{data.leaveHours} 小時 ({(data.leaveHours / 8).toFixed(1)} 天)
         </Typography>
-        <Typography>代理人員 ID：{data.proxyEmployeeId}</Typography>
+        <Typography>代理人員工編號：{data.proxyEmployeeId}</Typography>
         <Typography>代理人姓名：{data.proxyEmployeeName}</Typography>
         <Typography>請假事由：{data.reason}</Typography>
         <Typography>

--- a/src/pages/LeaveReviewDialog.tsx
+++ b/src/pages/LeaveReviewDialog.tsx
@@ -8,8 +8,10 @@ import {
   Button,
   Typography,
   TextField,
-  Link,
+  IconButton,
+  Alert,
 } from '@mui/material';
+import LinkIcon from '@mui/icons-material/Link';
 
 interface LeaveReviewDialogProps {
   open: boolean;
@@ -19,7 +21,7 @@ interface LeaveReviewDialogProps {
   leaveId: number | null;
   approvalReason: string;
   setApprovalReason: (value: string) => void;
-  downloadAttachment: (fileName: string) => string;
+  downloadAttachment: (fileName: string) => Promise<void>;
 }
 
 const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
@@ -45,17 +47,39 @@ const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
     proxyEmployeeId: number;
     proxyEmployeeName: string;
     fileName?: string;
+    filePath?: string;
   }>(null);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     if (leaveId !== null && open) {
       getLeave(leaveId).then((res) => {
         setData(res);
+        setApprovalReason('');
+        setError('');
       });
     } else {
       setData(null);
     }
-  }, [leaveId, open]);
+  }, [leaveId, open, setApprovalReason]);
+
+  const handleApprove = async () => {
+    if (!approvalReason.trim()) {
+      setError('請填寫主管留言');
+      return;
+    }
+    await approveLeave(data!.leaveApplicationId, approvalReason);
+    onApprove();
+  };
+
+  const handleReject = async () => {
+    if (!approvalReason.trim()) {
+      setError('請填寫主管留言');
+      return;
+    }
+    await rejectLeave(data!.leaveApplicationId, approvalReason);
+    onReject();
+  };
 
   if (!data) return null;
 
@@ -63,6 +87,11 @@ const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>審核請假申請</DialogTitle>
       <DialogContent dividers>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
         <Typography>員工編號：{data.employeeId}</Typography>
         <Typography>員工姓名：{data.employeeName}</Typography>
         <Typography>假別：{data.leaveTypeName}</Typography>
@@ -77,10 +106,14 @@ const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
         <Typography>請假事由：{data.reason}</Typography>
         <Typography>
           附件：
-          {data.fileName ? (
-            <Link href={downloadAttachment(data.fileName)} target="_blank" rel="noopener">
-              📎 {data.fileName}
-            </Link>
+          {data.fileName && data.filePath ? (
+            <IconButton
+              color="primary"
+              onClick={() => downloadAttachment(data.filePath as string)}
+              aria-label="下載附件"
+            >
+              <LinkIcon />
+            </IconButton>
           ) : (
             '—'
           )}
@@ -91,26 +124,24 @@ const LeaveReviewDialog: React.FC<LeaveReviewDialogProps> = ({
           multiline
           rows={3}
           value={approvalReason}
-          onChange={(e) => setApprovalReason(e.target.value)}
+          onChange={(e) => {
+            setApprovalReason(e.target.value);
+            setError('');
+          }}
+          error={!!error}
           sx={{ mt: 2 }}
         />
       </DialogContent>
       <DialogActions>
         <Button
-          onClick={async () => {
-            await approveLeave(data.leaveApplicationId, approvalReason);
-            onApprove();
-          }}
+          onClick={handleApprove}
           variant="contained"
           color="success"
         >
           同意
         </Button>
         <Button
-          onClick={async () => {
-            await rejectLeave(data.leaveApplicationId, approvalReason);
-            onReject();
-          }}
+          onClick={handleReject}
           variant="contained"
           color="error"
         >


### PR DESCRIPTION
- Added a column to show the employee name who submitted the leave request  
- Automatically refresh the leave request table after approving a request

**The response of the /api/manager/leaves API should include the employeeName property.**

```json
{
  "code": 1073741824,
  "msg": "string",
  "data": [
    {
      "applicationId": 1073741824,
      **"employeeName": "string"**,
      "leaveTypeName": "string",
      "startDateTime": "2025-05-25T13:42:11.535Z",
      "endDateTime": "2025-05-25T13:42:11.535Z",
      "leaveHours": 1073741824,
      "status": "string",
      "applicationDateTime": "2025-05-25T13:42:11.535Z"
    }
  ]
}
```

<img width="1159" alt="image" src="https://github.com/user-attachments/assets/0ab27aa0-d728-4e3d-8450-a41de075a509" />
